### PR TITLE
Set default text color for components

### DIFF
--- a/public/views/partials/pages/styleguide/index.liquid
+++ b/public/views/partials/pages/styleguide/index.liquid
@@ -1,4 +1,4 @@
-<div class="flex antialiased text-gray-900 bg-gray-100">
+<div class="flex antialiased text-normal bg-gray-100">
   {% render 'modules/components/components/sidebar', component_groups: component_groups %}
 
   <div class="flex-1">

--- a/public/views/partials/pages/styleguide/show.liquid
+++ b/public/views/partials/pages/styleguide/show.liquid
@@ -1,5 +1,4 @@
-<div class="flex antialiased text-gray-900 bg-gray-100">
+<div class="flex antialiased bg-gray-100">
   {% render 'modules/components/components/sidebar', component_groups: component_groups %}
   {% include 'modules/components/components/view', component: component, example_position: 'right' %}
 </div>
- 


### PR DESCRIPTION
# Description

The Style Guide forced the text colors to be some default Tailwind instead of what we need from Figma...

## Issue ticket number and link
https://trello.com/c/xPaG43O7/94-component-library-uses-incorrect-font