### PR TITLE
Added an input with a label and message molecule

### DIFF
--- a/public/views/pages/sandbox/input-with-label.liquid
+++ b/public/views/pages/sandbox/input-with-label.liquid
@@ -1,0 +1,34 @@
+---
+layout: modules/components/styleguide
+---
+
+<div class="m-4 flex flex-col justify-center flex-wrap gap-4">
+
+  {% liquid
+    assign input_params = '{}' | parse_json | hash_merge: name: 'input-standalone'
+    assign label_params = '{}' | parse_json | hash_merge: content: 'This is a standard fieldset'
+    assign description_params = '{}' | parse_json | hash_merge: content: 'This is the field description'
+    assign fieldset_params = '{}' | parse_json | hash_merge: label_params: label_params, input_params: input_params, description_params: description_params
+    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+  %}
+
+  {% liquid
+    assign input_params = '{}' | parse_json | hash_merge: name: 'input-confirmed'
+    assign label_params = '{}' | parse_json | hash_merge: content: 'This is a confirmed fieldset'
+    assign validation = '{}' | parse_json | hash_merge: passed: true
+    assign description_params = '{}' | parse_json | hash_merge: content: 'This is the field description'
+    assign fieldset_params = '{}' | parse_json | hash_merge: validation: validation, label_params: label_params, input_params: input_params, description_params: description_params
+    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+  %}
+
+  {% liquid
+    assign input_params = '{}' | parse_json | hash_merge: name: 'input-error'
+    assign label_params = '{}' | parse_json | hash_merge: content: 'This is a fieldset with some errors'
+    assign error_messages = '["First error message", "Second error message"]' | parse_json
+    assign validation = '{}' | parse_json | hash_merge: passed: false, messages: error_messages
+    assign description_params = '{}' | parse_json | hash_merge: content: 'This is the field description'
+    assign fieldset_params = '{}' | parse_json | hash_merge: validation: validation, label_params: label_params, input_params: input_params, description_params: description_params
+    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+  %}
+
+</div>

--- a/public/views/partials/atoms/input.liquid
+++ b/public/views/partials/atoms/input.liquid
@@ -34,7 +34,6 @@ metadata:
   assign value = params.value
   assign required = params.required | default: false
   assign disabled = params.disabled | default: false
-  assign error = params.error | default: false
   assign placeholder = params.placeholder
   assign id = params.attributes.id | default: name
   assign attributes = params.attributes
@@ -44,7 +43,7 @@ metadata:
   case variant
     when 'confirmation'
       assign classes = classes | append: ' border-confirmation'
-    when 'important'
+    when 'error'
       assign classes = classes | append: ' border-important'
     else
       assign classes = classes | append: ' border-input-border'
@@ -59,7 +58,8 @@ metadata:
   {% if value != blank %}value="{{value}}"{% endif %}
   {% if placeholder != blank %}placeholder="{{placeholder}}"{% endif %}
   {% if disabled %}disabled{% endif %}
+  {% if variant == 'error' %}aria-invalid="true"{% endif %}
   {% for attribute in attributes %}
-  {{ attribute[0] }}="{{ attribute[1] }}"
+    {{ attribute[0] }}="{{ attribute[1] }}"
   {% endfor %}
 >

--- a/public/views/partials/molecules/input-with-label.liquid
+++ b/public/views/partials/molecules/input-with-label.liquid
@@ -1,0 +1,93 @@
+---
+metadata:
+  name: Input with label
+  params:
+    tag: 'fieldset'
+    classes: ''
+    validation:
+      passed:
+        - true
+        - false
+      messages: []
+    input_params:
+      name: 'text-input-with-label-example'
+      placeholder: Type here
+    label_params:
+      content: Text input with label
+    description_params:
+      content: This is a description
+  styleguide:
+    params:
+      tag: 'div'
+      classes: ''
+      validation:
+        passed: false
+        messages: ['This is a test error message', 'Another error message']
+      input_params:
+        name: 'text-input-with-label-example'
+        placeholder: Type here
+      label_params:
+        content: Text input with label
+      description_params:
+        content: This is a description
+
+---
+{% liquid
+  assign tag = params.tag | default: 'fieldset'
+  assign label_params = params.label_params
+  assign input_attributes = '{}' | parse_json
+    hash_assign input_attributes['aria-describedby'] = '' | append: params.input_params.name | append: '-desc'
+  assign input_params = params.input_params | hash_merge: attributes: input_attributes
+    if params.validation.passed == false
+      hash_assign input_params['variant'] = 'error'
+    endif
+  assign description_params = params.description_params
+  assign validation = params.validation
+
+  assign classes = '' | append: params.classes
+%}
+<{{tag}} class="flex flex-col items-start gap-1 {{classes}}">
+
+  <label for="{{input_params.name}}" class="leading-tight">
+    {{label_params.content}}
+    {% if input_params.required %} <span class="text-important">*</span>{% endif %}
+  </label>
+
+  {% theme_render_rc 'components/atoms/input', params: input_params %}
+
+  {% if description_params.content or validation.messages.size > 0 %}
+    <div id="{{input_params.name}}-desc" class="flex gap-2">
+
+        {% if validation.passed == true %}
+          {% assign icon_params = '{}' | parse_json | hash_merge: name: 'checkBadge' %}
+          <span class="text-confirmation">
+            {% theme_render_rc 'components/atoms/icon', params: icon_params %}
+          </span>
+        {% endif %}
+
+        {% if validation.passed == false %}
+          {% assign icon_params = '{}' | parse_json | hash_merge: name: 'warningCloud' %}
+          <span class="text-important">
+            {% theme_render_rc 'components/atoms/icon', params: icon_params %}
+          </span>
+        {% endif %}
+
+        <div class="leading-none">
+          {% theme_render_rc 'components/atoms/sidenote', params: description_params %}
+
+          {% if validation.passed == false %}
+            <ul>
+              {% for message in validation.messages %}
+                <li class="flex items-center">
+                  {% assign description_params = '{}' | parse_json | hash_merge: content: message, classes: '!text-important' %}
+                  {% theme_render_rc 'components/atoms/sidenote', params: description_params %}
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+
+    </div>
+  {% endif %}
+
+</{{tag}}>


### PR DESCRIPTION
# Description

- Fixed the error styling in the `input` atom
- Added an input with a label and message molecule
- The molecule supports validation and validation messages
- It requires a lot of `hash_merge` to work, I don't know if there is any better idea on how to handle those, it feels it will become hard to manage in the organisms :<
- Again, added sandbox for testing. I don't know if we support showing various states of those bigger components in the automated Style Guide, I guess there is a room for improvement

![image](https://user-images.githubusercontent.com/1907443/190151883-58eaae46-df6b-450b-8ba3-5b8e0a5d1905.png)

## Issue ticket number and link
https://trello.com/c/Z9jTSRfF/97-form-elements-molecule
