### PR TITLE
Fix/component render

### DIFF
--- a/public/views/partials/atoms/backdrop.liquid
+++ b/public/views/partials/atoms/backdrop.liquid
@@ -20,6 +20,6 @@ metadata:
     assign classes = classes | append: ' hidden'
   endif
 %}
-<div data-backdrop-id="{{backdrop_id}}"
-  class="{{classes}}"
->{{content}}</div>
+<div data-backdrop-id="{{backdrop_id}}" class="{{classes}}">
+  {% print content %}
+</div>

--- a/public/views/partials/atoms/heading.liquid
+++ b/public/views/partials/atoms/heading.liquid
@@ -42,6 +42,8 @@ metadata:
   {% for attribute in attributes %}
   {{ attribute[0] }}="{{ attribute[1] }}"
   {% endfor %}
->{{content}}</{{tag}}>
+>
+  {% print content %}
+</{{tag}}>
 
 

--- a/public/views/partials/atoms/sidenote.liquid
+++ b/public/views/partials/atoms/sidenote.liquid
@@ -18,5 +18,7 @@ metadata:
   {% for attribute in attributes %}
   {{ attribute[0] }}="{{ attribute[1] }}"
   {% endfor %}
->{{content}}</small>
+>
+  {% print content %}
+</small>
 

--- a/public/views/partials/molecules/iconbutton.liquid
+++ b/public/views/partials/molecules/iconbutton.liquid
@@ -10,6 +10,7 @@ metadata:
       weight: secondary
       content: Upload
       variant: confirmation
+      attributes: attributes
     icon_params:
       name: folderUpload
   styleguide:


### PR DESCRIPTION
# Description

We need to replace variable interpolation {{ content }} with {% print content %} or {{ content | html_safe }} in every component where the default content sanitization could mess up the content (mostly in case of component composition).

## Issue ticket number and link
https://trello.com/c/gnU1A2hh/154-component-content-bug

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
