### PR TITLE
Button atom fixes

### DIFF
--- a/public/views/partials/atoms/button.liquid
+++ b/public/views/partials/atoms/button.liquid
@@ -23,6 +23,8 @@ metadata:
     disabled:
       - false
       - true
+    attributes: {}
+    href: ''
     content: Click me
     type: 'button'
 ---
@@ -37,6 +39,9 @@ metadata:
   assign attributes = params.attributes
   assign content = params.content
   assign href = params.href
+  if href
+    assign tag = params.tag | default: 'a'
+  endif
 
   assign classes = params.classes | append: ' inline-flex items-center justify-center gap-3 rounded whitespace-nowrap transition-colors disabled:opacity-30 disabled:pointer-events-none'
   if tag == 'a'
@@ -85,7 +90,8 @@ metadata:
   {% for attribute in attributes %}
     {{ attribute[0] }}="{{ attribute[1] }}"
   {% endfor %}
+  {% if href %}href="{{href}}"{% endif %}
   {% if tag == 'button' and disabled %}disabled{% endif %}
   {% if tag == 'button' %}type="{{type}}"{% endif %}
->{{content}}</{{tag}}>
+>{{content | html_safe}}</{{tag}}>
 


### PR DESCRIPTION
# Description

Added missing `href`
If there is no `tag` specified but `href` is present then the default tag should be `a`
Added `html_safe` to `{{content}}` to avoid interpolation lobotomy 💀 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
