### PR TITLE
Add default border color

### DIFF
--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -77,6 +77,9 @@ module.exports = {
         'warning-hover': parseColor('warning-hover'),
         'warning-disabled': parseColor('warning-disabled')
       },
+      borderColor: {
+        DEFAULT: parseColor('divider')
+      },
       boxShadow: {
         'card': `0px 0px 5px rgba(${defaultColors['shadow']}, .1)`,
         'large': `0px 10px 30px rgba(${defaultColors['shadow']}, .3)`


### PR DESCRIPTION
# Description

Add `divider` as default border color

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
