### PR TITLE
Set start page and end page when count is less than maxcount in pagination molecule

### DIFF
--- a/public/views/partials/molecules/pagination.liquid
+++ b/public/views/partials/molecules/pagination.liquid
@@ -32,7 +32,7 @@ metadata:
     assign endPage = active | plus: limit
   endif
 
-  if count == maxCount
+  if count <= maxCount
     assign startPage = 1
     assign endPage = count
   endif


### PR DESCRIPTION
# Description

Show the pager correctly if the count is less than the max count in pager.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
