### PR TITLE
New secondary button variant: Decline

### DIFF
--- a/public/views/partials/atoms/button.liquid
+++ b/public/views/partials/atoms/button.liquid
@@ -14,6 +14,7 @@ metadata:
       - important
       - confirmation
       - inverted
+      - declination
     filled:
       - false
       - true
@@ -75,6 +76,8 @@ metadata:
         assign classes = classes | append: ' border-important hover:border-important-hover text-important hover:text-important-hover'
       when 'confirmation'
         assign classes = classes | append: ' border-confirmation hover:border-confirmation-hover text-confirmation hover:text-confirmation-hover'
+      when 'declination'
+        assign classes = classes | append: ' border-button-secondary-stroke hover:border-button-secondary-stroke-hover text-button-secondary-foreground hover:text-button-secondary-foreground-hover hover:bg-warning-disabled'
     endcase
 
     if filled


### PR DESCRIPTION
# Description

Add new variant for secondary button called 'declination' that has a more visible color on hover state.

## Issue ticket number and link

https://trello.com/c/fciq6gbU/224-decline-button-in-user-approval-has-no-hover-state-approve-has

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
