### PR TITLE
Fix for iPhone multi-select default placeholder padding

### DIFF
--- a/public/views/partials/molecules/select.liquid
+++ b/public/views/partials/molecules/select.liquid
@@ -160,7 +160,7 @@ metadata:
   </div>
 
   <select
-    class="pos-select--multi-native h-11 border border-input-border bg-panel {{classes}}"
+    class="pos-select--multi-native h-11 border border-input-border bg-panel px-2 {{classes}}"
     name="{{name}}[]"
     multiple
     aria-labelledby="{{name}}"


### PR DESCRIPTION
# Description

Fix for iPhone multi-select default placeholder padding

## Issue ticket number and link

https://trello.com/c/Z5eDQVc2/387-formatting-needs-fixing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
