### PR TITLE
dynamic buttonDisabled

### DIFF
--- a/public/views/partials/atoms/button.liquid
+++ b/public/views/partials/atoms/button.liquid
@@ -23,6 +23,8 @@ metadata:
     disabled:
       - false
       - true
+    buttonDisabled:
+      - Name of a dynamic variable that the JS framework will use to decide the state of the button
     attributes: {}
     href: ''
     content: Click me
@@ -97,5 +99,6 @@ metadata:
   {% if href and disabled != true %}href="{{href}}"{% endif %}
   {% if tag == 'button' and disabled %}disabled{% endif %}
   {% if tag == 'button' %}type="{{type}}"{% endif %}
+  {% if buttonDisabled != blank %}:disabled="{{buttonDisabled}}"{% endif %}
 >{{content | html_safe}}</{{tag}}>
 


### PR DESCRIPTION
# Description

Disable `atoms/button` temporarily after click.

## Issue ticket number and link

Used in:
https://trello.com/c/WwIp31lD/128-group-invite-new-member-functionality-not-working

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
