### PR TITLE
Hide popup after selecting an option

### DIFF
--- a/modules/components/src/scripts/components/popup.js
+++ b/modules/components/src/scripts/components/popup.js
@@ -30,7 +30,6 @@ const closePopup = popupId => {
 const popupOpeners = document.querySelectorAll('[data-popup-open-id]');
 popupOpeners.forEach(opener => {
   opener.addEventListener('click', (event) => {
-    event.stopPropagation();
     const popupId = opener.getAttribute('data-popup-open-id');
     togglePopup(popupId);
   });


### PR DESCRIPTION
# Description

Removes stop propagation on event, which caused the dropdown to stay in the open state.

## Issue ticket number and link
https://github.com/Platform-OS/styleseeker/issues/570
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
